### PR TITLE
Added exception to gitignore for VS project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
+!Intermediate/ProjectFiles/*
 
 # Cache files for the editor to use
 DerivedDataCache/*


### PR DESCRIPTION
This should make it so we don't have to generate the VS project files manually.