### PR TITLE
Fixed build errors caused by ThirdPersonExampleMap and added Plugin intermediates to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,10 +68,17 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
-!Intermediate/ProjectFiles/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
 
 # Whitelist plugins folder
 !Plugins/**
+
+# Intermediates from the plugins folder
+Plugins/SettingFunctionality/Intermediate
+Plugins/AdvancedSessions/AdvancedSessions/Intermediate
+Plugins/AdvancedSessions/AdvancedSteamSessions/Intermediate
+
+# Whitelist Visual Studio project files
+!Intermediate/ProjectFiles/*


### PR DESCRIPTION
This is a change that Phanatik came up with tonight but forgot to commit. I added the plugin intermediates to the .gitignore so hopefully they won't bother us anymore.